### PR TITLE
Fix blockers discovered testing on my work mac

### DIFF
--- a/spacehammer/config.example.fnl
+++ b/spacehammer/config.example.fnl
@@ -325,7 +325,7 @@
 (local common-keys
        [{:mods [:alt]
          :key :space
-         :action "lib.modal:activate-modal"}
+         :action "spacehammer.lib.modal:activate-modal"}
         {:mods [:alt]
          :key :n
          :action "apps:next-app"}

--- a/spacehammer/core.fnl
+++ b/spacehammer/core.fnl
@@ -1,4 +1,10 @@
-(hs.ipc.cliInstall) ; ensure CLI installed
+;; ensure CLI installed
+(let [homebrew-silicon-prefix "/opt/homebrew"]
+  ;; check package.path for the homebrew's fallpack path to unbreak CLI installs on arm64
+  ;; hardware. See https://github.com/Hammerspoon/hammerspoon/pull/3082 for more info.
+  (if (string.find homebrew-silicon-prefix package.path)
+      (hs.ipc.cliInstall homebrew-silicon-prefix)
+      (hs.ipc.cliInstall)))
 
 (local fennel (require :spacehammer.vendor.fennel))
 (require :spacehammer.lib.globals)

--- a/spacehammer/core.fnl
+++ b/spacehammer/core.fnl
@@ -99,8 +99,8 @@ Returns nil. This function causes side-effects.
 
 ;; If ~/.spacehammer/config.fnl does not exist
 ;; - Create ~/.spacehammer dir
-;; - Copy default ~/.hammerspoon/config.example.fnl to ~/.spacehammer/config.fnl
-(let [example-path (.. homedir "/.hammerspoon/config.example.fnl")
+;; - Copy default config.example.fnl to ~/.spacehammer/config.fnl
+(let [example-path (hs.spoons.resourcePath "config.example.fnl")
       target-path (.. customdir "/config.fnl")]
   (when (not (file-exists? target-path))
     (log.d (.. "Copying " example-path " to " target-path))


### PR DESCRIPTION
This is a set of pretty small, fairly unrelated fixes, but I needed it to get spacehammer running from a clean slate without error.

So:
- fix filepath used to initially install the user config (still used `.hammerspoon` instead of the spoon resource path)
- fix reference to modal function in example config (was missing new `spacehammer.` prefix)
- conditionally pass the conventional homebrew prefix used on silicon macs if it's present in hammerspoon's `package.path` string.
 
The last one is a basic, slightly hacky heuristic, but one which shouldn't have any false negatives: it will only pass that path if it's actually valid. For edge cases this doesn't catch but which don't work with the default (e.g. an M1 mac with a nonstandard homebrew path, an intel mac where `$USER` doesn't have permissions to access `/usr/local` for some reason), it will just fall back to the existing behavior, so at least there won't be any regression.