### PR TITLE
Get tests running in new directory structure

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -15,12 +15,10 @@ function Spacehammer:init()
   fennel = require("spacehammer.vendor.fennel")
   fennel.path = scriptPath .. "?.fnl;" .. scriptPath .. "?/init.fnl;" .. fennel.path
   fennel['macro-path'] = scriptPath .. "?.fnl;" .. scriptPath .. "?/init-macros.fnl;" .. scriptPath .. "?/init.fnl;" .. fennel.path
-  print(hs.inspect(package.searchers))
   table.insert(package.loaders or package.searchers, fennel.searcher)
 end
 
 function Spacehammer:start()
-  print(hs.inspect(package.searchers))
   require('spacehammer.core')
   hs.alert.show("Spacehammer config loaded")
 end

--- a/run-test
+++ b/run-test
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-exec hs ./lib/testing/test.lua "$(pwd)" "$@"
+exec hs -c "" ./spacehammer/lib/testing/test.lua "$(pwd)" "$@"

--- a/spacehammer/lib/testing/test-runner.fnl
+++ b/spacehammer/lib/testing/test-runner.fnl
@@ -5,12 +5,15 @@
         : pprint}  (require :spacehammer.lib.functional))
 
 ;; Setup some globals for test files and debugging
+
+
 (global {: after
          : before
          : describe
          : it} (require :spacehammer.lib.testing))
 
 ;; Pull in some locals from the testing library as well
+
 (local {: init
         : collect-tests
         : run-all-tests} (require :spacehammer.lib.testing))
@@ -29,7 +32,10 @@
         (print "Running tests for" test-file-path)
         (fennel.dofile test-file-path))))
 
+
+
   (collect-tests)
   (run-all-tests))
+
 
 {: load-tests}

--- a/spacehammer/lib/testing/test-runner.fnl
+++ b/spacehammer/lib/testing/test-runner.fnl
@@ -1,5 +1,4 @@
 (local fennel (require :spacehammer.vendor.fennel))
-(print "Imported fennel")
 (require :spacehammer.lib.globals)
 (local {: map
         : slice

--- a/spacehammer/lib/testing/test-runner.fnl
+++ b/spacehammer/lib/testing/test-runner.fnl
@@ -1,27 +1,31 @@
+(print "Package path in test-runner") ; DELETEME
+(print package.path) ; DELETEME
+; (local fennel (require :fennel))
 (local fennel (require :spacehammer.vendor.fennel))
+(print "Fennel path in test-runner") ; DELETEME
+(print fennel.path) ; DELETEME
+; (local fennel (require :spacehammer.vendor.fennel))
+(print "Imported fennel")
 (require :spacehammer.lib.globals)
 (local {: map
         : slice
         : pprint}  (require :spacehammer.lib.functional))
 
-(local homedir (os.getenv "HOME"))
-(local customdir (.. homedir "/.spacehammer"))
-(tset fennel :path (.. customdir "/?.fnl;" fennel.path))
-(tset fennel :path (.. customdir "/?/init.fnl;" fennel.path))
+; (local homedir (os.getenv "HOME"))
+; (local customdir (.. homedir "/.spacehammer"))
+; (tset fennel :path (.. customdir "/?.fnl;" fennel.path))
+; (tset fennel :path (.. customdir "/?/init.fnl;" fennel.path))
 
 ;; Setup some globals for test files and debugging
-
-
 (global {: after
          : before
          : describe
-         : it} (require :lib.testing))
+         : it} (require :spacehammer.lib.testing))
 
 ;; Pull in some locals from the testing library as well
-
 (local {: init
         : collect-tests
-        : run-all-tests} (require :lib.testing))
+        : run-all-tests} (require :spacehammer.lib.testing))
 
 (fn load-tests
   [args]
@@ -30,6 +34,8 @@
   Takes a list of args starting with a directory
   Runs each test file using fennel.dofile
   "
+  (print "in load-tests") ; DELETEME
+  (print "xx" (hs.inspect args)) ; DELETEME
   (init)
   (let [[dir & test-files] (slice 2 args)]
     (each [i test-file (ipairs test-files)]
@@ -37,10 +43,7 @@
         (print "Running tests for" test-file-path)
         (fennel.dofile test-file-path))))
 
-
-
   (collect-tests)
   (run-all-tests))
-
 
 {: load-tests}

--- a/spacehammer/lib/testing/test-runner.fnl
+++ b/spacehammer/lib/testing/test-runner.fnl
@@ -1,20 +1,9 @@
-(print "Package path in test-runner") ; DELETEME
-(print package.path) ; DELETEME
-; (local fennel (require :fennel))
 (local fennel (require :spacehammer.vendor.fennel))
-(print "Fennel path in test-runner") ; DELETEME
-(print fennel.path) ; DELETEME
-; (local fennel (require :spacehammer.vendor.fennel))
 (print "Imported fennel")
 (require :spacehammer.lib.globals)
 (local {: map
         : slice
         : pprint}  (require :spacehammer.lib.functional))
-
-; (local homedir (os.getenv "HOME"))
-; (local customdir (.. homedir "/.spacehammer"))
-; (tset fennel :path (.. customdir "/?.fnl;" fennel.path))
-; (tset fennel :path (.. customdir "/?/init.fnl;" fennel.path))
 
 ;; Setup some globals for test files and debugging
 (global {: after
@@ -34,8 +23,6 @@
   Takes a list of args starting with a directory
   Runs each test file using fennel.dofile
   "
-  (print "in load-tests") ; DELETEME
-  (print "xx" (hs.inspect args)) ; DELETEME
   (init)
   (let [[dir & test-files] (slice 2 args)]
     (each [i test-file (ipairs test-files)]

--- a/spacehammer/lib/testing/test.lua
+++ b/spacehammer/lib/testing/test.lua
@@ -33,4 +33,3 @@ local testRunner = require("spacehammer.lib.testing.test-runner")
 print(testRunner) -- DELETEME
 -- TODO: Knock off the first arg, which is the base script path
 testRunner["load-tests"](_cli.args)
-return {}

--- a/spacehammer/lib/testing/test.lua
+++ b/spacehammer/lib/testing/test.lua
@@ -17,7 +17,5 @@ fennel["macro-path"] = scriptPath .. "?.fnl;" .. scriptPath .. "?/init-macros.fn
 
 table.insert(package.loaders or package.searchers, fennel.searcher)
 
-print("Loading test-runner")
 local testRunner = require("spacehammer.lib.testing.test-runner")
--- TODO: Knock off the first arg, which is the base script path
 testRunner["load-tests"](_cli.args)

--- a/spacehammer/lib/testing/test.lua
+++ b/spacehammer/lib/testing/test.lua
@@ -8,28 +8,16 @@ if _cli.args[3] == nil then
   return
 end
 
--- package.path = package.path .. ";" .. scriptPath .. "?.lua;" .. scriptPath .. "?/init.lua;"
--- package.cpath = package.cpath .. ";" .. scriptPath .. "?.so;"
-package.path = scriptPath .. "?.lua;" .. scriptPath .. "?/init.lua;" .. package.path .. ";"
-package.cpath = scriptPath .. "?.so;" .. package.cpath
-print("Package path in test.lua") -- DELETEME
-print(package.path) -- DELETEME
+package.path = package.path .. ";" .. scriptPath .. "?.lua;" .. scriptPath .. "?/init.lua;"
+package.cpath = package.cpath .. ";" .. scriptPath .. "?.so;"
 
--- fennel = require("fennel")
 fennel = require("spacehammer.vendor.fennel")
 fennel.path = scriptPath .. "?.fnl;" .. scriptPath .. "?/init.fnl;"
--- fennel.path = scriptPath .. "?.fnl;" .. scriptPath .. "?/init.fnl;" .. fennel.path
 fennel["macro-path"] = scriptPath .. "?.fnl;" .. scriptPath .. "?/init-macros.fnl;" .. scriptPath .. "?/init.fnl;"
--- fennel["macro-path"] = scriptPath .. "?.fnl;" .. scriptPath .. "?/init-macros.fnl;" .. scriptPath .. "?/init.fnl;" .. fennel.path
-print("Fennel path in test.lua") -- DELETEME
-print(fennel.path) -- DELETEME
 
 table.insert(package.loaders or package.searchers, fennel.searcher)
 
 print("Loading test-runner")
--- local testRunner = fennel.dofile("../lib/testing/test-runner.fnl")
--- local testRunner = require("spacehammer.lib.testing.assert")
 local testRunner = require("spacehammer.lib.testing.test-runner")
-print(testRunner) -- DELETEME
 -- TODO: Knock off the first arg, which is the base script path
 testRunner["load-tests"](_cli.args)

--- a/spacehammer/lib/testing/test.lua
+++ b/spacehammer/lib/testing/test.lua
@@ -1,15 +1,36 @@
 --test.lua
 -- A script to run fennel files as tests passed in as cli args
 
+local scriptPath = _cli.args[2] .. "/"
 
+if _cli.args[3] == nil then
+  print("Need to specify tests")
+  return
+end
+
+-- package.path = package.path .. ";" .. scriptPath .. "?.lua;" .. scriptPath .. "?/init.lua;"
+-- package.cpath = package.cpath .. ";" .. scriptPath .. "?.so;"
+package.path = scriptPath .. "?.lua;" .. scriptPath .. "?/init.lua;" .. package.path .. ";"
+package.cpath = scriptPath .. "?.so;" .. package.cpath
+print("Package path in test.lua") -- DELETEME
+print(package.path) -- DELETEME
+
+-- fennel = require("fennel")
 fennel = require("spacehammer.vendor.fennel")
+fennel.path = scriptPath .. "?.fnl;" .. scriptPath .. "?/init.fnl;"
+-- fennel.path = scriptPath .. "?.fnl;" .. scriptPath .. "?/init.fnl;" .. fennel.path
+fennel["macro-path"] = scriptPath .. "?.fnl;" .. scriptPath .. "?/init-macros.fnl;" .. scriptPath .. "?/init.fnl;"
+-- fennel["macro-path"] = scriptPath .. "?.fnl;" .. scriptPath .. "?/init-macros.fnl;" .. scriptPath .. "?/init.fnl;" .. fennel.path
+print("Fennel path in test.lua") -- DELETEME
+print(fennel.path) -- DELETEME
 
--- Support docstrings
+table.insert(package.loaders or package.searchers, fennel.searcher)
 
-local searcher = fennel.makeSearcher({
-      useMetadata = true,
-})
-
-local testRunner = require "lib.testing.test-runner"
-
+print("Loading test-runner")
+-- local testRunner = fennel.dofile("../lib/testing/test-runner.fnl")
+-- local testRunner = require("spacehammer.lib.testing.assert")
+local testRunner = require("spacehammer.lib.testing.test-runner")
+print(testRunner) -- DELETEME
+-- TODO: Knock off the first arg, which is the base script path
 testRunner["load-tests"](_cli.args)
+return {}

--- a/spacehammer/test/advice-test.fnl
+++ b/spacehammer/test/advice-test.fnl
@@ -8,7 +8,6 @@
         : get-advice
         : print-advisable-keys} (require :spacehammer.lib.advice))
 
-(local fennel (require :spacehammer.vendor.fennel))
 (local is (require :spacehammer.lib.testing.assert))
 (local {: join
         : map} (require :spacehammer.lib.functional))


### PR DESCRIPTION
work in progress.

* Use `-c ""` to avoid running the users _~/.hammerspoon/init.lua_
* Provide the base path to the test runner, since `hs.spoons.scriptPath` doesn't work when run from the cli
* Fix import paths