### PR TITLE
Extract helpers from `core.fnl` and add `init.example.fnl`

### DIFF
--- a/spacehammer/config.example.fnl
+++ b/spacehammer/config.example.fnl
@@ -9,15 +9,6 @@
         :logf logf} (require :spacehammer.lib.functional))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; WARNING
-;; Make sure you are customizing ~/.spacehammer/config.fnl and not
-;; ~/.hammerspoon/config.fnl
-;; Otherwise you will lose your customizations on upstream changes.
-;; A copy of this file should already exist in your ~/.spacehammer directory.
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Table of Contents
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -91,9 +82,6 @@
 ;; General
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; If you would like to customize this we recommend copying this file to
-;; ~/.spacehammer/config.fnl. That will be used in place of the default
-;; and will not be overwritten by upstream changes when spacehammer is updated.
 (local music-app "Spotify")
 
 (local return

--- a/spacehammer/core.fnl
+++ b/spacehammer/core.fnl
@@ -51,19 +51,26 @@
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; create custom config file if it doesn't exist
+;; create custom config and/or init files if either doesn't exist
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
 ;; If ~/.spacehammer/config.fnl does not exist
 ;; - Create ~/.spacehammer dir
 ;; - Copy default config.example.fnl to ~/.spacehammer/config.fnl
-(let [example-path (hs.spoons.resourcePath "config.example.fnl")
-      target-path (.. customdir "/config.fnl")]
-  (when (not (file-exists? target-path))
-    (log.d (.. "Copying " example-path " to " target-path))
+;; If ~/.spacehammer/init.fnl does not exist
+;; - Copy default init.example.fnl to ~/.spacehammer/init.fnl
+(let [example-config-path (hs.spoons.resourcePath "config.example.fnl")
+      example-init-path (hs.spoons.resourcePath "init.example.fnl")
+      target-config-path (.. customdir "/config.fnl")
+      target-init-path (.. customdir "/init.fnl")]
+  (when (not (file-exists? target-config-path))
+    (log.d (.. "Copying " example-config-path " to " target-config-path))
     (hs.fs.mkdir customdir)
-    (copy-file example-path target-path)))
+    (copy-file example-config-path target-config-path))
+  (when (not (file-exists? target-init-path))
+    (log.d (.. "Copying " example-init-path " to " target-init-path))
+    (copy-file example-init-path target-init-path)))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -76,21 +83,6 @@
 (when (file-exists? (.. customdir "/config.fnl"))
   (global custom-files-watcher (watch-files customdir)))
 
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Set utility keybindings
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-
-;; toggle hs.console with Ctrl+Cmd+~
-(hs.hotkey.bind
- [:ctrl :cmd] "`" nil
- (fn []
-   (if-let
-    [console (hs.console.hswindow)]
-    (when (= console (hs.console.hswindow))
-      (hs.closeConsole))
-    (hs.openConsole))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Load custom init.fnl file (if it exists)

--- a/spacehammer/core.fnl
+++ b/spacehammer/core.fnl
@@ -41,29 +41,6 @@
 (set hs.hints.fontSize 30)
 (set hs.window.animationDuration 0.2)
 
-"
-alert :: str, { style }, seconds -> nil
-Shortcut for showing an alert on the primary screen for a specified duration
-Takes a message string, a style table, and the number of seconds to show alert
-Returns nil. This function causes side-effects.
-"
-(global alert
-        (afn
-         alert
-         [str style seconds]
-         "
-         Global alert function used for spacehammer modals and reload
-         alerts after config reloads
-         "
-         (hs.alert.show str
-                        style
-                        (hs.screen.primaryScreen)
-                        seconds)))
-
-(global fw hs.window.focusedWindow)
-
-(global pprint (fn [x] (print (fennel.view x))))
-
 (global get-config
         (afn get-config
           []

--- a/spacehammer/init.example.fnl
+++ b/spacehammer/init.example.fnl
@@ -1,0 +1,11 @@
+(require-macros :spacehammer.lib.macros)
+
+;; toggle hs.console with Ctrl+Cmd+~
+(hs.hotkey.bind
+ [:ctrl :cmd] "`" nil
+ (fn []
+   (if-let
+    [console (hs.console.hswindow)]
+    (when (= console (hs.console.hswindow))
+      (hs.closeConsole))
+    (hs.openConsole))))

--- a/spacehammer/lib/files.fnl
+++ b/spacehammer/lib/files.fnl
@@ -1,0 +1,92 @@
+(local {: contains?
+        : split
+        : some} (require :spacehammer.lib.functional))
+
+(fn file-exists?
+  [filepath]
+  "
+  Determine if a file exists and is readable.
+  Takes a file path string
+  Returns true if file is readable
+  "
+  (let [file (io.open filepath "r")]
+    (when file
+      (io.close file))
+    (~= file nil)))
+
+(fn copy-file
+  [source dest]
+  "
+  Copies the contents of a source file to a destination file.
+  Takes a source file path and a destination file path.
+  Returns nil
+  "
+  (let [default-config (io.open source "r")
+        custom-config (io.open dest "a")]
+    (each [line _ (: default-config :lines)]
+      (: custom-config :write (.. line "\n")))
+    (: custom-config :close)
+    (: default-config :close)))
+
+(fn source-filename?
+  [file]
+  "
+  Determine if a file is not an emacs backup file which starts with \".#\"
+  Takes a file path string
+  Returns true if it's a source file and not an emacs backup file.
+  "
+  (not (string.match file ".#")))
+
+(fn source-extension?
+  [file]
+  "
+  Determine if a file is a .fnl or .lua file
+  Takes a file string
+  Returns true if file extension ends in .fnl or .lua
+  "
+  (let [ext (split "%p" file)]
+    (and
+     (or (contains? "fnl" ext)
+         (contains? "lua" ext))
+     (not (string.match file "-test%..*$")))))
+
+(fn source-updated?
+  [file]
+  "
+  Determine if a file is a valid source file that we can load
+  Takes a file string path
+  Returns true if file is not an emacs backup and is a .fnl or .lua type.
+  "
+  (and (source-filename? file)
+       (source-extension? file)))
+
+(fn config-reloader
+  [files]
+  "
+  If the list of files contains some hammerspoon or spacehammer source files:
+  reload hammerspoon
+  Takes a list of files from our config file watcher.
+  Performs side effect of reloading hammerspoon.
+  Returns nil
+  "
+  (when (some source-updated? files)
+    (hs.alert "Spacehammer reloaded")
+    (hs.console.clearConsole)
+    (hs.reload)))
+
+(fn watch-files
+  [dir]
+  "
+  Watches hammerspoon or spacehammer source files. When a file updates we reload
+  hammerspoon.
+  Takes a directory to watch.
+  Returns a function to stop the watcher.
+  "
+  (let [watcher (hs.pathwatcher.new dir config-reloader)]
+    (: watcher :start)
+    (fn []
+      (: watcher :stop))))
+
+{: file-exists?
+ : copy-file
+ : watch-files}

--- a/spacehammer/lib/files.fnl
+++ b/spacehammer/lib/files.fnl
@@ -17,7 +17,7 @@
 (fn copy-file
   [source dest]
   "
-  Copies the contents of a source file to a destination file.
+  Copy the contents of a source file to a destination file.
   Takes a source file path and a destination file path.
   Returns nil
   "
@@ -63,9 +63,8 @@
 (fn config-reloader
   [files]
   "
-  If the list of files contains some hammerspoon or spacehammer source files:
-  reload hammerspoon
-  Takes a list of files from our config file watcher.
+  Reload hammerspoon if the list of files contains some hammerspoon or spacehammer source files
+  Takes a list of files (intended for use with our config file watcher).
   Performs side effect of reloading hammerspoon.
   Returns nil
   "
@@ -77,8 +76,7 @@
 (fn watch-files
   [dir]
   "
-  Watches hammerspoon or spacehammer source files. When a file updates we reload
-  hammerspoon.
+  Watch a directory of source files. When a file updates we reload hammerspoon.
   Takes a directory to watch.
   Returns a function to stop the watcher.
   "

--- a/spacehammer/lib/globals.fnl
+++ b/spacehammer/lib/globals.fnl
@@ -1,5 +1,6 @@
 (local fennel (require :spacehammer.vendor.fennel))
 (local {: map} (require :spacehammer.lib.functional))
+(require-macros :spacehammer.lib.advice.macros)
 
 (global pprint
         (fn pprint
@@ -13,3 +14,24 @@
                     "table" (fennel.view $1)
                     _       $1)
                  [...])))))
+
+"
+alert :: str, { style }, seconds -> nil
+Shortcut for showing an alert on the primary screen for a specified duration
+Takes a message string, a style table, and the number of seconds to show alert
+Returns nil. This function causes side-effects.
+"
+(global alert
+        (afn
+         alert
+         [str style seconds]
+         "
+         Global alert function used for spacehammer modals and reload
+         alerts after config reloads
+         "
+         (hs.alert.show str
+                        style
+                        (hs.screen.primaryScreen)
+                        seconds)))
+
+(global fw hs.window.focusedWindow)


### PR DESCRIPTION
I started out intending to pare down the example config, but got sidetracked trying to streamline `core.fnl`. I think the changes make sense, though, so:
- extract all the file-oriented helper functions from `core.fnl` to a new `lib/files.fnl`
- extract most globals from `core.fnl` into `lib/globals.fnl` (with the exception of `get-config`, which has its own set of special considerations); I'm very willing to be convinced that any given global definition should be moved back
- extract the random utility keybind for toggling the console to a new `init.example.fnl` and update the "copy over initial user config file" logic to account for it. This is the biggest user-facing change, but I think it's fair: it enhances the discoverability of the user `init.fnl` file's special role and it moves the keybinding somewhere the user can easily change it to suit themself.